### PR TITLE
Fix Struct type infinite recursion

### DIFF
--- a/src/proto.ts
+++ b/src/proto.ts
@@ -73,7 +73,8 @@ export function jsonTemplate(message: protobuf.Type): any {
     }
     if (
       field.resolvedType !== null &&
-      field.resolvedType instanceof protobuf.Type
+      field.resolvedType instanceof protobuf.Type &&
+      field.type !== 'Struct' // the Struct type can have nested structs, which causes infinite recursion
     ) {
       tmpl[field.name] = jsonTemplate(field.resolvedType);
       return;


### PR DESCRIPTION
This PR makes a change to prevent `google.protobuf.Struct` types from recursing. Because `Struct`s can have nested `Struct`s, this ends up causing infinite recursion in this function, causing the page to not render. See https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Struct

### Todo
- [ ] Deploy