### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/proto.ts
+++ b/src/proto.ts
@@ -98,7 +98,7 @@ export function jsonTemplate(message: protobuf.Type): any {
 
 // Returns obj.fullName without the first period.
 export function fullName(obj: protobuf.ReflectionObject) {
-  return obj.fullName[0] === '.' ? obj.fullName.substr(1) : obj.fullName;
+  return obj.fullName[0] === '.' ? obj.fullName.slice(1) : obj.fullName;
 }
 
 export const typeName = (obj: protobuf.ReflectionObject): string => {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.